### PR TITLE
Strikeout Todo Item

### DIFF
--- a/to-do-app/src/components/ListItem/index.js
+++ b/to-do-app/src/components/ListItem/index.js
@@ -64,7 +64,7 @@ class ListItem extends Component {
           disableRipple
         />
         <input
-          className="item-text"
+          className={this.props.item.completed ? "item-text completed-item" : "item-text"}
           type="text"
           value={this.state.itemName}
           disabled={this.state.immutable}

--- a/to-do-app/src/components/ListItem/index.js
+++ b/to-do-app/src/components/ListItem/index.js
@@ -23,7 +23,12 @@ class ListItem extends Component {
   }
   
   updateItemStatus() {
+    if (!this.state.immutable) {
+      return;
+    }
+
     this.props.item.completed = !this.props.item.completed;
+    this.props.saveActiveList(this.props.activeList);
     this.props.updateList();
   }
 
@@ -60,20 +65,22 @@ class ListItem extends Component {
     return (
       <div className="item">
         <Checkbox
-          defaultChecked={this.props.item.completed}
+          checked={this.props.item.completed}
           onChange={this.updateItemStatusHandler}
           icon={<CheckBoxOutlineBlankOutlinedIcon />}
           checkedIcon={<CheckBoxOutlinedIcon />}
           color="default"
           disableRipple
+          data-testid="checkBox"
         />
         <input
           className={this.props.item.completed ? "item-text completed-item" : "item-text"}
           type="text"
           value={this.state.itemName}
-          disabled={this.state.immutable}
+          readOnly={this.state.immutable}
           onChange={event => this.setItemNameHandler(event.target.value)}
-          onBlur={this.updateItemNameHandler}>
+          onBlur={this.updateItemNameHandler}
+          onClick={this.updateItemStatusHandler}>
         </input>
         <div className="icons">
           <EditIcon

--- a/to-do-app/src/components/ListItem/index.js
+++ b/to-do-app/src/components/ListItem/index.js
@@ -27,7 +27,11 @@ class ListItem extends Component {
     this.props.updateList();
   }
 
-  deleteItem () {
+  deleteItem() {
+    if (this.props.item.completed) {
+      return;
+    }
+
     let removalItemId = this.props.item.id;
     let remainingItems = this.props.activeList.items.filter((item) => {
         return item.id != removalItemId});
@@ -73,12 +77,12 @@ class ListItem extends Component {
         </input>
         <div className="icons">
           <EditIcon
-            className="edit-icon"
+            className={this.props.item.completed ?  "hidden" :  "edit-icon"}
             data-testid="editIcon"
             onClick={this.setImmutableHandler}
           />
           <DeleteIcon 
-            className="delete-icon"
+            className={this.props.item.completed ?  "hidden" :  "delete-icon"}
             data-testid="deleteIcon"
             onClick={this.deleteItemHandler}
           />

--- a/to-do-app/src/components/ListItem/index.test.js
+++ b/to-do-app/src/components/ListItem/index.test.js
@@ -144,3 +144,14 @@ test("changes an item for active list", () => {
   
   expect(wrapper.instance().props.activeList).toStrictEqual(expected);
 });
+
+
+test("uses 'complited-item' style selector if item is completed", () => {
+  const testItem = {"id": 1, "name": "First Item", "completed": true};
+
+  const wrapper = shallow(<ListItem item={testItem}/>);
+
+  const item = wrapper.find("input");
+
+  expect(item.hasClass('item-text completed-item')).toBeTruthy();
+});

--- a/to-do-app/src/components/ListItem/index.test.js
+++ b/to-do-app/src/components/ListItem/index.test.js
@@ -48,21 +48,21 @@ test("checkbox is marked if item is done", () => {
 test("checkbox completed switches states after click", () => {
   const testItem = {"id": 1, "name": "First Item", "completed": true}
 
-  render(<ListItem item={testItem} updateList={() => null}/>);
+  render(<ListItem item={testItem} updateList={() => null} saveActiveList={() => null}/>);
 
   const checkbox = screen.getByRole("checkbox");
 
-  fireEvent.click(checkbox);
-
+  fireEvent.change(checkbox, { target: {checked: false}})
+  
   expect(checkbox.checked).toBeFalsy();
 });
 
 test("changes the status of active list", () => {
   const testItem = {"id": 1, "name": "First Item", "completed": false}
 
-  const wrapper = shallow(<ListItem item={testItem} updateList={() => null}/>);
+  const wrapper = shallow(<ListItem item={testItem} updateList={() => null} saveActiveList={() => null}/>);
   
-  render(<ListItem item={testItem} updateList={() => null}/>);
+  render(<ListItem item={testItem} updateList={() => null} saveActiveList={() => null}/>);
 
   const checkbox = screen.getByRole("checkbox");
 
@@ -100,14 +100,14 @@ test("renders edit button icon", () => {
   expect(icon).toBeInTheDocument();
 });
 
-test("item is disabled for editing by default", () => {
+test("item is readonly for editing by default", () => {
   const testItem = {"id": 1, "name": "First Item", "completed": false}
 
-  render(<ListItem item={testItem}/>);
+  const wrapper = shallow(<ListItem item={testItem}/>);
 
-  const item = screen.getByRole("textbox");
+  const item = wrapper.find("input");
 
-  expect(item).toBeDisabled();
+  expect(item.prop('readOnly')).toEqual(true);
 });
 
 test("item is editable when click EditIcon", () => {
@@ -120,7 +120,7 @@ test("item is editable when click EditIcon", () => {
 
   const item = wrapper.find("input");
 
-  expect(item.prop('disabled')).toEqual(false);
+  expect(item.prop('readOnly')).toEqual(false);
 });
 
 test("changes an item for active list", () => {
@@ -179,4 +179,21 @@ test("doesn't remove completed item", () => {
   wrapper.find(DeleteIcon).simulate("click");
   
   expect(wrapper.instance().props.activeList).toEqual(testList);
+});
+
+test("strikeout item and mark as completed on click", () => {
+  const testItem = {"id": 1, "name": "First Item", "completed": false}
+
+  const wrapper = shallow(<ListItem item={testItem} updateList={() => null} saveActiveList={() => null}/>);
+
+  render(<ListItem item={testItem} updateList={() => null} saveActiveList={() => null}/>);
+
+  const item = wrapper.find("input");
+  item.simulate("click");
+
+  wrapper.instance().forceUpdate()
+  const updatedItem = wrapper.find("input");
+
+  expect(wrapper.instance().props.item.completed).toBeTruthy();
+  expect(updatedItem.hasClass('item-text completed-item')).toBeTruthy();
 });

--- a/to-do-app/src/components/ListItem/index.test.js
+++ b/to-do-app/src/components/ListItem/index.test.js
@@ -90,7 +90,6 @@ test("removes an item from active list", () => {
   expect(wrapper.instance().props.activeList).toEqual(expected);
 });
 
-
 test("renders edit button icon", () => {
   const testItem = {"id": 1, "name": "First Item", "completed": false}
 
@@ -145,7 +144,6 @@ test("changes an item for active list", () => {
   expect(wrapper.instance().props.activeList).toStrictEqual(expected);
 });
 
-
 test("uses 'complited-item' style selector if item is completed", () => {
   const testItem = {"id": 1, "name": "First Item", "completed": true};
 
@@ -154,4 +152,31 @@ test("uses 'complited-item' style selector if item is completed", () => {
   const item = wrapper.find("input");
 
   expect(item.hasClass('item-text completed-item')).toBeTruthy();
+});
+
+test("uses 'hidden' style selector for icons if item is completed", () => {
+  const testItem = {"id": 1, "name": "First Item", "completed": true};
+
+  const wrapper = shallow(<ListItem item={testItem}/>);
+
+  const editIcon = wrapper.find(EditIcon);
+  const deleteIcon = wrapper.find(DeleteIcon);
+
+  expect(editIcon.hasClass('hidden')).toBeTruthy();
+  expect(deleteIcon.hasClass('hidden')).toBeTruthy();
+});
+
+test("doesn't remove completed item", () => {
+  const testItem = {"id": 1, "name": "Should Not Be Deleted", "completed": true}
+  const testList = { "id": 1, "title": "Dummy Title", "items": 
+                      [ testItem ] }
+
+  const wrapper = shallow(<ListItem activeList={testList}
+                                    saveActiveList={(list) => list}
+                                    item={testItem}
+                                    updateList={() => null}/>);
+  
+  wrapper.find(DeleteIcon).simulate("click");
+  
+  expect(wrapper.instance().props.activeList).toEqual(testList);
 });

--- a/to-do-app/src/components/ListItem/style.css
+++ b/to-do-app/src/components/ListItem/style.css
@@ -19,6 +19,10 @@
   background-color: transparent;
 }
 
+.item input[readonly] {
+  cursor: pointer;
+}
+
 .item:hover {
   background-color: #F3F4F9;
   border-radius: 10px 10px 10px 10px;

--- a/to-do-app/src/components/ListItem/style.css
+++ b/to-do-app/src/components/ListItem/style.css
@@ -46,3 +46,7 @@
   font-style: italic;
   color: #757575;
 }
+
+.hidden {
+  visibility: hidden;
+}

--- a/to-do-app/src/components/ListItem/style.css
+++ b/to-do-app/src/components/ListItem/style.css
@@ -40,3 +40,9 @@
   margin-right: 12px;
   color: #E47B7B;
 }
+
+.completed-item {
+  text-decoration: line-through;
+  font-style: italic;
+  color: #757575;
+}

--- a/to-do-app/src/components/ListView/index.test.js
+++ b/to-do-app/src/components/ListView/index.test.js
@@ -11,28 +11,28 @@ test("renders logo if active list is empty", () => {
 });
 
 test("renders appropriate number of list items", () => {
-    const testList = {"title": "First Test Title", "items": [
-        {"id": 1, "name": "First Item", "completed": false},
-        {"id": 2, "name": "Second Item", "completed": false},
-        {"id": 3, "name": "Third", "completed": false}]}
+  const testList = {"title": "First Test Title", "items": [
+    {"id": 1, "name": "First Item", "completed": false},
+    {"id": 2, "name": "Second Item", "completed": false},
+    {"id": 3, "name": "Third", "completed": false}]}
 
-    render(<ListView activeList = {testList}/>);
+  render(<ListView activeList = {testList}/>);
   
-    const items = screen.getAllByRole("checkbox");
+  const items = screen.getAllByRole("checkbox");
 
-    expect(items).toHaveLength(3);
-  });
+  expect(items).toHaveLength(3);
+});
 
-  test("renders items from to-do list", () => {
-    const testList = {"title": "First Test Title", "items": [
-        {"id": 1, "name": "First Item", "completed": false},
-        {"id": 2, "name": "Second Item", "completed": false}]}
+test("renders items from to-do list", () => {
+  const testList = {"title": "First Test Title", "items": [
+    {"id": 1, "name": "First Item", "completed": false},
+    {"id": 2, "name": "Second Item", "completed": false}]}
 
-    render(<ListView activeList = {testList}/>);
+  render(<ListView activeList = {testList}/>);
   
-    const newItem = screen.getByTestId("newItem");
+  const newItem = screen.getByTestId("newItem");
 
-    expect(newItem).toBeInTheDocument();
-    expect(screen.getByDisplayValue(/First Item/i)).toBeInTheDocument();
-    expect(screen.getByDisplayValue(/Second Item/i)).toBeInTheDocument();
-  });
+  expect(newItem).toBeInTheDocument();
+  expect(screen.getByDisplayValue(/First Item/i)).toBeInTheDocument();
+  expect(screen.getByDisplayValue(/Second Item/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
**As** a user
**I want** to see the completed items striked
**And** be able to strikeout item when click on the it
**And** when mark the item as done
**So that** it allows to easy find completed items

**Given:** The ListView and displayed items
**When:** The user click on the item
**And/Or:** marks the item as done
**Then:** The items has been strikeout
**And:** The user can't delete the striked item

[Trello](https://trello.com/c/VocdCWji/8-strikeout-todo-item)

Current design:
<img width="1571" alt="image" src="https://user-images.githubusercontent.com/89826596/156614422-e22e7ba4-f369-457b-9708-2431d8ac69e4.png">

Expected design:
<img width="1399" alt="image" src="https://user-images.githubusercontent.com/89826596/154993994-8aa86117-fbb6-400a-80ad-c044274d72ec.png">