### PR TITLE
Fix Bug for Editing Item

### DIFF
--- a/to-do-app/src/components/ListItem/index.js
+++ b/to-do-app/src/components/ListItem/index.js
@@ -55,7 +55,12 @@ class ListItem extends Component {
   }
 
   updateItemName() {
+    // if (!this.state.immutable) {
+    //   return;
+    // }
+    
     this.props.item.name = this.state.itemName;
+    // this.props.changeActiveList(this.props.activeList);
     this.props.updateList();
 
     this.setImmutable();

--- a/to-do-app/src/components/ListItem/index.js
+++ b/to-do-app/src/components/ListItem/index.js
@@ -32,7 +32,7 @@ class ListItem extends Component {
     this.props.updateList();
   }
 
-  deleteItem() {
+  async deleteItem() {
     if (this.props.item.completed) {
       return;
     }
@@ -43,7 +43,7 @@ class ListItem extends Component {
 
     this.props.activeList.items = remainingItems;
     this.props.changeActiveList(this.props.activeList);
-    this.props.updateList();
+    await this.props.updateList();
   }
 
   setImmutable() {
@@ -55,12 +55,12 @@ class ListItem extends Component {
   }
 
   updateItemName() {
-    // if (!this.state.immutable) {
-    //   return;
-    // }
+    if (this.state.immutable) {
+      return;
+    }
     
     this.props.item.name = this.state.itemName;
-    // this.props.changeActiveList(this.props.activeList);
+    this.props.changeActiveList(this.props.activeList);
     this.props.updateList();
 
     this.setImmutable();

--- a/to-do-app/src/components/ListItem/index.test.js
+++ b/to-do-app/src/components/ListItem/index.test.js
@@ -128,7 +128,7 @@ test("changes an item for active list", () => {
   const testList = { "id": 1, "title": "Dummy Title", "items": 
                       [ testItem ] }
 
-  const wrapper = shallow(<ListItem activeList={testList} item={testItem} updateList={() => null}/>);
+  const wrapper = shallow(<ListItem activeList={testList} item={testItem} updateList={() => null} changeActiveList={() => null}/>);
 
   const icon = wrapper.find(EditIcon);
   icon.simulate('click');
@@ -172,7 +172,6 @@ test("doesn't remove completed item", () => {
                       [ testItem ] }
 
   const wrapper = shallow(<ListItem activeList={testList}
-                                    saveActiveList={(list) => list}
                                     item={testItem}
                                     updateList={() => null}/>);
   


### PR DESCRIPTION
Fixed bug that allowed to rename completed item when different item in editing mode.

[Trello](https://trello.com/c/Q6mASEuK/21-fix-bug-for-editing-item)
